### PR TITLE
Removed CONVERT helper variables

### DIFF
--- a/Tests/helper.py
+++ b/Tests/helper.py
@@ -257,16 +257,22 @@ def netpbm_available():
     return bool(shutil.which("ppmquant") and shutil.which("ppmtogif"))
 
 
-def convert_available():
-    return imagemagick_available() or graphicsmagick_available()
+def magick_command():
+    if sys.platform == "win32":
+        imagemagick = os.environ.get("MAGICK_HOME", "")
+        if imagemagick:
+            imagemagick = [os.path.join(imagemagick, "convert.exe")]
+            graphicsmagick = [os.path.join(imagemagick, "gm.exe"), "convert"]
+        else:
+            graphicsmagick = None
+    else:
+        imagemagick = ["convert"]
+        graphicsmagick = ["gm", "convert"]
 
-
-def imagemagick_available():
-    return bool(IMCONVERT and shutil.which(IMCONVERT[0]))
-
-
-def graphicsmagick_available():
-    return bool(GMCONVERT and shutil.which(GMCONVERT[0]))
+    if imagemagick and shutil.which(imagemagick[0]):
+        return imagemagick
+    elif graphicsmagick and shutil.which(graphicsmagick[0]):
+        return graphicsmagick
 
 
 def on_appveyor():
@@ -302,24 +308,6 @@ def is_pypy():
 
 def is_mingw():
     return sysconfig.get_platform() == "mingw"
-
-
-if sys.platform == "win32":
-    IMCONVERT = os.environ.get("MAGICK_HOME", "")
-    GMCONVERT = None
-    if IMCONVERT:
-        IMCONVERT = [os.path.join(IMCONVERT, "convert.exe")]
-        GMCONVERT = [os.path.join(IMCONVERT, "gm.exe"), "convert"]
-else:
-    IMCONVERT = ["convert"]
-    GMCONVERT = ["gm", "convert"]
-
-if imagemagick_available():
-    CONVERT = IMCONVERT
-elif graphicsmagick_available():
-    CONVERT = GMCONVERT
-else:
-    CONVERT = None
 
 
 class cached_property:

--- a/Tests/test_file_palm.py
+++ b/Tests/test_file_palm.py
@@ -5,9 +5,7 @@ import pytest
 
 from PIL import Image
 
-from .helper import CONVERT, assert_image_equal, convert_available, hopper
-
-_roundtrip = convert_available()
+from .helper import assert_image_equal, hopper, magick_command
 
 
 def helper_save_as_palm(tmp_path, mode):
@@ -23,13 +21,10 @@ def helper_save_as_palm(tmp_path, mode):
     assert os.path.getsize(outfile) > 0
 
 
-def open_with_convert(tmp_path, f):
-    if not convert_available():
-        raise OSError()
-
+def open_with_magick(magick, tmp_path, f):
     outfile = str(tmp_path / "temp.png")
     rc = subprocess.call(
-        CONVERT + [f, outfile], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
+        magick + [f, outfile], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT
     )
     if rc:
         raise OSError
@@ -37,14 +32,15 @@ def open_with_convert(tmp_path, f):
 
 
 def roundtrip(tmp_path, mode):
-    if not _roundtrip:
+    magick = magick_command()
+    if not magick:
         return
 
     im = hopper(mode)
     outfile = str(tmp_path / "temp.palm")
 
     im.save(outfile)
-    converted = open_with_convert(tmp_path, outfile)
+    converted = open_with_magick(magick, tmp_path, outfile)
     assert_image_equal(converted, im)
 
 


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/5349

Takes `CONVERT`, `IMCONVERT`, `GMCONVERT`, `convert_available()`, `imagemagick_available()`, `graphicsmagick_available()` and replaces them with a single method - `magick_command()`.

I feel like this is simpler.