### PR TITLE
Moved GmDisplayViewer into API Additions

### DIFF
--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -86,3 +86,15 @@ PyQt6
 
 Support has been added for PyQt6. If it is installed, it will be used instead of
 PySide6, PyQt5 or PySide2.
+
+GraphicsMagick
+^^^^^^^^^^^^^^
+
+Support has been added for GraphicsMagick_ as an alternative to ImageMagick_.  This
+includes GraphicsMagick as a viewer (cf.
+:py:class:`PIL.ImageShow.GmDisplayViewer <PIL.ImageShow.UnixViewer.GmDisplayViewer>`)
+and the capability to run the test suite with GraphicsMagick instead of ImageMagick.
+If both are installed, the test suite prefers ImageMagick over GraphicsMagick.
+
+.. _GraphicsMagick: http://www.graphicsmagick.org/
+.. _ImageMagick: https://imagemagick.org/

--- a/docs/releasenotes/8.2.0.rst
+++ b/docs/releasenotes/8.2.0.rst
@@ -65,6 +65,18 @@ instances, so it will only be used by ``im.show()`` or :py:func:`.ImageShow.show
 if none of the other viewers are available. This means that the behaviour of
 :py:class:`PIL.ImageShow` will stay the same for most Pillow users.
 
+ImageShow.GmDisplayViewer
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If GraphicsMagick is present, this new :py:class:`PIL.ImageShow.Viewer` subclass will
+be registered. It uses GraphicsMagick_, an ImageMagick_ fork, to display images.
+
+If both ImageMagick and GraphicsMagick are installed, ImageMagick will be used.
+
+.. _GraphicsMagick: http://www.graphicsmagick.org/
+.. _ImageMagick: https://imagemagick.org/
+
+
 Saving TIFF with ICC profile
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -86,15 +98,3 @@ PyQt6
 
 Support has been added for PyQt6. If it is installed, it will be used instead of
 PySide6, PyQt5 or PySide2.
-
-GraphicsMagick
-^^^^^^^^^^^^^^
-
-Support has been added for GraphicsMagick_ as an alternative to ImageMagick_.  This
-includes GraphicsMagick as a viewer (cf.
-:py:class:`PIL.ImageShow.GmDisplayViewer <PIL.ImageShow.UnixViewer.GmDisplayViewer>`)
-and the capability to run the test suite with GraphicsMagick instead of ImageMagick.
-If both are installed, the test suite prefers ImageMagick over GraphicsMagick.
-
-.. _GraphicsMagick: http://www.graphicsmagick.org/
-.. _ImageMagick: https://imagemagick.org/


### PR DESCRIPTION
Helps https://github.com/python-pillow/Pillow/pull/5349

This PR moves your documentation from "Other Changes" into "API Additions", because, well, it is technically an API addition.

You will then realise that in 8.2.0, we've actually already added one other new ImageShow.Viewer subclass - IPythonViewer (https://github.com/python-pillow/Pillow/pull/5289). So this PR also updates your text so that they are more similar to each other. Feel free to tell me that you think your version is better worded in parts.

I'm also correcting
> If both are installed, the test suite prefers ImageMagick over GraphicsMagick.

It's not just the test suite that prefers ImageMagick. `im.show()` does as well.

See https://pillow-radarhere.readthedocs.io/en/graphicsmagick/releasenotes/8.2.0.html#api-additions for how it looks.